### PR TITLE
Probe active Sync Module XR manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       # avant d'avoir un vrai compte Blink pour aller plus loin.
       - name: Demarrer le conteneur et interroger la page
         run: |
-          docker run -d --name blink2video-ci -p 127.0.0.1:8765:8765 blink2video:ci
+          docker run -d --name blink2video-ci -e BLINK_TRUSTED_LOOPBACK_PROXY=1 -p 127.0.0.1:8765:8765 blink2video:ci
           for i in $(seq 1 20); do
             if curl -sf http://127.0.0.1:8765/ -o page.html; then break; fi
             sleep 1

--- a/.github/workflows/verify-docker-hub.yml
+++ b/.github/workflows/verify-docker-hub.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Demarrer le conteneur
         run: |
-          docker run -d --name verif -p 127.0.0.1:8765:8765 \
+          docker run -d --name verif -e BLINK_TRUSTED_LOOPBACK_PROXY=1 -p 127.0.0.1:8765:8765 \
             "nico579dock/blink2video:${{ github.event.inputs.tag }}"
 
       - name: Attendre que la page reponde

--- a/README-XR-test.txt
+++ b/README-XR-test.txt
@@ -1,0 +1,20 @@
+Blink Sync Module XR test r2 (Windows 10/11 x64)
+===================================================
+
+1. Close blink2video.
+2. Put Tester-XR.exe in the same folder as blink2video.exe. It replaces nothing.
+3. Double-click Tester-XR.exe and allow a few minutes for the manifest request.
+4. The anonymized report opens automatically.
+5. Paste the complete report into your Reddit reply; no separate upload is needed.
+
+The tester uses the Blink session already saved by blink2video. It reads the
+account inventory and directly requests the local-storage manifest. It does not
+download or delete clips, start Live View, or change any camera setting.
+
+The report contains only software versions, yes/no states, counts, error classes
+and a short one-way error reference. It contains no password, authentication
+token, serial number, camera/network name, raw identifier, URL or raw API reply.
+
+If the report says LOGIN REQUIRED, open blink2video normally, sign in, close it,
+then run Tester-XR.exe again from the same folder. Do not rerun the test more
+than once per minute because the Sync Module needs time to build its manifest.

--- a/blink_models.py
+++ b/blink_models.py
@@ -254,9 +254,12 @@ async def read_local_manifest(sync) -> list:
     import asyncio
 
     storage = sync._local_storage  # blinkpy n'expose pas encore d'accesseur public.
-    if not storage.get("compatible"):
-        raise RuntimeError("ce hub n'est pas compatible avec le stockage local")
-    if not storage.get("enabled"):
+    # Un vrai Sync Module XR avec microSD active annonce
+    # ``compatible=false, enabled=true, status=active``. Le premier drapeau
+    # décrit donc une compatibilité historique (notamment USB), pas la capacité
+    # opérationnelle à lire le manifeste XR. blinkpy ne bloque lui-même que sur
+    # ``status`` : un stockage actif est la preuve la plus forte et doit primer.
+    if not sync.local_storage and not storage.get("enabled"):
         raise RuntimeError("le stockage local n'est pas activé sur ce hub")
     if not sync.local_storage:
         raise RuntimeError(

--- a/build_xr_tester.py
+++ b/build_xr_tester.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import shutil
 import sys
+import zipfile
 from pathlib import Path
 
 import build
@@ -17,6 +18,8 @@ VENV = BASE_DIR / "build_venv"
 WORK = BASE_DIR / "build-xr-tester"
 DIST = BASE_DIR / "dist-xr-tester"
 SPEC = BASE_DIR / "xr_tester.spec"
+README = BASE_DIR / "README-XR-test.txt"
+PACKAGE_REVISION = "r2"
 
 
 def preparer_version_info() -> Path:
@@ -79,7 +82,18 @@ def main() -> int:
     executable = DIST / "Tester-XR.exe"
     if not executable.is_file():
         raise SystemExit(f"Testeur introuvable : {executable}")
+    if not README.is_file():
+        raise SystemExit(f"Instructions introuvables : {README}")
+
+    package = DIST / (
+        f"Tester-XR-blink2video-{runtime.VERSION}-{PACKAGE_REVISION}-windows-x64.zip"
+    )
+    with zipfile.ZipFile(package, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.write(executable, executable.name)
+        archive.write(README, README.name)
+
     print(f"\nTesteur construit : {executable}")
+    print(f"Paquet transmissible : {package}")
     print("À placer dans le même dossier que blink2video.exe, puis double-cliquer.")
     return 0
 

--- a/diagnostic_xr.py
+++ b/diagnostic_xr.py
@@ -25,7 +25,8 @@ import runtime
 
 
 REPORT_NAME = "blink2video-XR-test-report.txt"
-TESTER_REVISION = "xr-local-storage-v1"
+TESTER_REVISION = "xr-local-storage-v2"
+_REQUIRED_CLIP_FIELDS = frozenset({"id", "camera_name", "created_at", "size"})
 
 def _package_version(name: str) -> str:
     try:
@@ -42,7 +43,11 @@ def _presence(value) -> str:
 def _safe_error(error: BaseException) -> str:
     """Classe et catégorie allowlistée, sans recopier le message arbitraire."""
     message = str(error).casefold()
-    if "pas compatible" in message or "not compatible" in message:
+    if "manifest request" in message:
+        category = "manifest request rejected"
+    elif "manifest response" in message:
+        category = "invalid manifest response"
+    elif "pas compatible" in message or "not compatible" in message:
         category = "local storage incompatible"
     elif "pas activ" in message or "not enabled" in message:
         category = "local storage disabled"
@@ -87,13 +92,48 @@ def _environment_lines() -> list[str]:
     ]
 
 
-async def inspect_blink(blink, select_modules=None, read_manifest=None) -> tuple[int, list[str]]:
+async def probe_local_manifest(sync) -> dict[str, int]:
+    """Sonde directement les deux routes du manifeste, sans recopier leur contenu."""
+    request = await sync.poll_local_storage_manifest()
+    if not isinstance(request, dict) or request.get("id") in (None, ""):
+        raise RuntimeError("manifest request response missing identifier")
+
+    response = await sync.poll_local_storage_manifest(request["id"])
+    if not isinstance(response, dict) or response.get("manifest_id") in (None, ""):
+        raise RuntimeError("manifest response missing manifest identifier")
+    raw_clips = response.get("clips")
+    if not isinstance(raw_clips, (list, tuple)):
+        raise RuntimeError("manifest response missing clips list")
+
+    clips = [clip for clip in raw_clips if isinstance(clip, dict)]
+    camera_references = {
+        str(clip["camera_name"])
+        for clip in clips
+        if clip.get("camera_name") not in (None, "")
+    }
+    names = getattr(sync, "_names_table", None)
+    names = names if isinstance(names, dict) else {}
+    return {
+        "clips": len(raw_clips),
+        "schema_clips": sum(
+            1 for clip in clips if _REQUIRED_CLIP_FIELDS.issubset(clip)
+        ),
+        "mapped_clips": sum(
+            1 for clip in clips if clip.get("camera_name") in names
+        ),
+        "cameras": len(camera_references),
+    }
+
+
+async def inspect_blink(
+    blink, select_modules=None, manifest_probe=None,
+) -> tuple[int, list[str]]:
     """Inspecte les métadonnées nécessaires, sans exposer leurs valeurs privées."""
-    if select_modules is None or read_manifest is None:
+    if select_modules is None:
         import blink_models
 
         select_modules = select_modules or blink_models.select_sync_modules
-        read_manifest = read_manifest or blink_models.read_local_manifest
+    manifest_probe = manifest_probe or probe_local_manifest
 
     homescreen = getattr(blink, "homescreen", None)
     homescreen = homescreen if isinstance(homescreen, dict) else {}
@@ -129,6 +169,7 @@ async def inspect_blink(blink, select_modules=None, read_manifest=None) -> tuple
 
     successful = 0
     clips_seen = 0
+    has_unusable_clips = False
     for index, (_name, sync) in enumerate(modules, start=1):
         storage = getattr(sync, "_local_storage", None)
         storage = storage if isinstance(storage, dict) else {}
@@ -147,6 +188,13 @@ async def inspect_blink(blink, select_modules=None, read_manifest=None) -> tuple
             f"compatible={_flag(storage, 'compatible')}, "
             f"enabled={_flag(storage, 'enabled')}, active={active}",
         ])
+        if active == "no":
+            lines.append("  manifest API: SKIPPED (local storage is not active)")
+            continue
+        if _flag(storage, "compatible") == "no":
+            lines.append(
+                "  compatibility flag: informational; active storage will be probed"
+            )
         try:
             # Même verrou inter-processus que le téléchargeur. Le testeur peut
             # ainsi être lancé pendant que l'interface tourne sans envoyer une
@@ -154,38 +202,52 @@ async def inspect_blink(blink, select_modules=None, read_manifest=None) -> tuple
             with runtime.verrou(
                 "hub", f"xr-diagnostic-{os.getpid()}", attente=10,
             ):
-                clips = list(await read_manifest(sync))
+                stats = await manifest_probe(sync)
         except Exception as error:
-            lines.append(f"  manifest: FAILED ({_safe_error(error)})")
+            lines.append(f"  manifest API: FAILED ({_safe_error(error)})")
             continue
 
         successful += 1
-        clips_seen += len(clips)
-        camera_count = len({str(getattr(clip, "name", "")) for clip in clips})
+        clip_count = int(stats["clips"])
+        schema_count = int(stats["schema_clips"])
+        mapped_count = int(stats["mapped_clips"])
+        clips_seen += clip_count
+        has_unusable_clips |= (
+            schema_count != clip_count or mapped_count != clip_count
+        )
         lines.extend([
-            "  manifest: OK",
-            f"  clips reported: {len(clips)}",
-            f"  cameras represented: {camera_count}",
+            "  manifest API: OK",
+            f"  clips reported by API: {clip_count}",
+            f"  clips matching expected schema: {schema_count}/{clip_count}",
+            f"  clips mapped to known cameras: {mapped_count}/{clip_count}",
+            f"  cameras represented: {int(stats['cameras'])}",
         ])
 
-    if successful == len(modules) and clips_seen:
+    if successful == len(modules) and clips_seen and not has_unusable_clips:
         lines.append(
-            "\nOverall result: PASS_WITH_CLIPS - local storage manifests are "
-            "accessible and contain clips."
+            "\nOverall result: PASS_WITH_CLIPS - the manifest API is accessible "
+            "and its clips are usable by blink2video."
         )
         return 0, lines
+    if successful == len(modules) and clips_seen:
+        lines.append(
+            "\nOverall result: PARTIAL - the manifest API is accessible, but not "
+            "every clip is usable by blink2video yet."
+        )
+        return 1, lines
     if successful == len(modules):
         lines.append(
-            "\nOverall result: PASS_EMPTY - local storage manifests are accessible "
-            "but contain no clips."
+            "\nOverall result: PASS_EMPTY - the manifest API is accessible but "
+            "currently reports no clips."
         )
         return 0, lines
     if successful:
         lines.append(
-            f"\nOverall result: PARTIAL - {successful}/{len(modules)} manifest(s) accessible."
+            f"\nOverall result: PARTIAL - {successful}/{len(modules)} manifest API "
+            "request(s) succeeded."
         )
         return 1, lines
-    lines.append("\nOverall result: FAIL - no local storage manifest was accessible.")
+    lines.append("\nOverall result: FAIL - no local storage manifest API was accessible.")
     return 1, lines
 
 
@@ -290,7 +352,7 @@ def main() -> int:
             "Keep Tester-XR.exe in the same folder as blink2video.exe.\n\n"
             "This read-only test checks the XR microSD manifest using the saved "
             "Blink session.\n\n"
-            "It can take up to one minute. Click OK to start; the report will open "
+            "It can take a few minutes. Click OK to start; the report will open "
             "automatically when finished."
         )
     path = report_path()
@@ -325,7 +387,8 @@ def main() -> int:
         return code
     _show_message(
         "The test is complete. The report will now open.\n\n"
-        "Please send this text file to the blink2video maintainer."
+        "You may paste its contents into the Reddit reply; the report contains "
+        "only anonymized statuses and counts."
     )
     try:
         _open_report(path)

--- a/test_diagnostic_xr.py
+++ b/test_diagnostic_xr.py
@@ -40,25 +40,29 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
             },
             sync={"Porte secrète": SimpleNamespace()},
         )
-        clips = [SimpleNamespace(name="Porte secrète"), SimpleNamespace(name="Porte secrète")]
-        read_manifest = mock.AsyncMock(return_value=clips)
+        manifest_probe = mock.AsyncMock(return_value={
+            "clips": 2,
+            "schema_clips": 2,
+            "mapped_clips": 2,
+            "cameras": 1,
+        })
 
         code, lines = await diagnostic_xr.inspect_blink(
             blink,
             select_modules=lambda _blink, _name: [("Jardin privé", sync)],
-            read_manifest=read_manifest,
+            manifest_probe=manifest_probe,
         )
         report = "\n".join(lines)
 
         self.assertEqual(code, 0)
-        self.assertIn("manifest: OK", report)
-        self.assertIn("clips reported: 2", report)
+        self.assertIn("manifest API: OK", report)
+        self.assertIn("clips reported by API: 2", report)
         self.assertIn("Overall result: PASS_WITH_CLIPS", report)
         for private in ("Jardin privé", "Porte secrète", "SECRET-SERIAL"):
             self.assertNotIn(private, report)
         self.assertNotIn("900", report)
         self.assertNotIn("network identifier: 7", report)
-        read_manifest.assert_awaited_once_with(sync)
+        manifest_probe.assert_awaited_once_with(sync)
 
     async def test_manifeste_vide_valide_la_route_sans_inventer_de_clips(self):
         sync = SimpleNamespace(
@@ -71,7 +75,12 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
         code, lines = await diagnostic_xr.inspect_blink(
             SimpleNamespace(homescreen={}, sync={}),
             select_modules=lambda _blink, _name: [("secret", sync)],
-            read_manifest=mock.AsyncMock(return_value=[]),
+            manifest_probe=mock.AsyncMock(return_value={
+                "clips": 0,
+                "schema_clips": 0,
+                "mapped_clips": 0,
+                "cameras": 0,
+            }),
         )
 
         self.assertEqual(code, 0)
@@ -81,11 +90,18 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
         from test_xr_local_storage import compte_avec_stockage_local
 
         blink, doorbell = compte_avec_stockage_local()
-        read_manifest = mock.AsyncMock(return_value=[])
-        with mock.patch("blink_models.read_local_manifest", new=read_manifest):
+        manifest_probe = mock.AsyncMock(return_value={
+            "clips": 0,
+            "schema_clips": 0,
+            "mapped_clips": 0,
+            "cameras": 0,
+        })
+        with mock.patch.object(
+            diagnostic_xr, "probe_local_manifest", new=manifest_probe,
+        ):
             code, lines = await diagnostic_xr.inspect_blink(blink)
 
-        selected = read_manifest.await_args.args[0]
+        selected = manifest_probe.await_args.args[0]
         self.assertEqual(code, 0)
         self.assertIsNot(selected, doorbell)
         self.assertEqual(str(selected.sync_id), "900")
@@ -100,7 +116,7 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
         code, lines = await diagnostic_xr.inspect_blink(
             blink,
             select_modules=lambda _blink, _name: [],
-            read_manifest=mock.AsyncMock(),
+            manifest_probe=mock.AsyncMock(),
         )
 
         self.assertEqual(code, 1)
@@ -135,7 +151,7 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
         code, lines = await diagnostic_xr.inspect_blink(
             blink,
             select_modules=mock.Mock(side_effect=RuntimeError(message)),
-            read_manifest=mock.AsyncMock(),
+            manifest_probe=mock.AsyncMock(),
         )
         report = "\n".join(lines)
 
@@ -145,6 +161,85 @@ class DiagnosticXRTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("blink_auth.json", report)
         self.assertNotIn("example.test", report)
         self.assertNotIn("abcdefghijklmnopqrstuvwxyz", report)
+
+    async def test_xr_actif_est_sonde_meme_si_compatible_vaut_faux(self):
+        poll = mock.AsyncMock(side_effect=[
+            {"id": 51},
+            {
+                "manifest_id": 61,
+                "clips": [{
+                    "id": 71,
+                    "camera_name": "CameraAnonyme",
+                    "created_at": "2026-08-31T10:00:00+00:00",
+                    "size": "128",
+                }],
+            },
+        ])
+        sync = SimpleNamespace(
+            network_id=7,
+            sync_id=900,
+            _local_storage={
+                "compatible": False,
+                "enabled": True,
+                "status": True,
+            },
+            local_storage=True,
+            _names_table={"CameraAnonyme": "Nom privé"},
+            poll_local_storage_manifest=poll,
+        )
+
+        code, lines = await diagnostic_xr.inspect_blink(
+            SimpleNamespace(homescreen={}, sync={}),
+            select_modules=lambda _blink, _name: [("secret", sync)],
+        )
+        report = "\n".join(lines)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            poll.await_args_list,
+            [mock.call(), mock.call(51)],
+        )
+        self.assertIn("compatible=no, enabled=yes, active=yes", report)
+        self.assertIn("compatibility flag: informational", report)
+        self.assertIn("clips matching expected schema: 1/1", report)
+        self.assertIn("clips mapped to known cameras: 1/1", report)
+        self.assertIn("PASS_WITH_CLIPS", report)
+        for private in ("CameraAnonyme", "Nom privé", "900", "51", "61", "71"):
+            self.assertNotIn(private, report)
+
+    async def test_manifeste_accessible_mais_camera_inconnue_est_partiel(self):
+        sync = SimpleNamespace(
+            network_id=7,
+            sync_id=900,
+            _local_storage={"compatible": False, "enabled": True, "status": True},
+            local_storage=True,
+        )
+        probe = mock.AsyncMock(return_value={
+            "clips": 2,
+            "schema_clips": 2,
+            "mapped_clips": 0,
+            "cameras": 1,
+        })
+
+        code, lines = await diagnostic_xr.inspect_blink(
+            SimpleNamespace(homescreen={}, sync={}),
+            select_modules=lambda _blink, _name: [("secret", sync)],
+            manifest_probe=probe,
+        )
+
+        self.assertEqual(code, 1)
+        self.assertIn("Overall result: PARTIAL", "\n".join(lines))
+
+    async def test_reponse_manifeste_invalide_reste_anonyme(self):
+        sync = SimpleNamespace(
+            poll_local_storage_manifest=mock.AsyncMock(
+                side_effect=[{"id": 51}, {"manifest_id": 61, "private": "SECRET"}],
+            ),
+            _names_table={},
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "manifest response"):
+            await diagnostic_xr.probe_local_manifest(sync)
 
     async def test_ecriture_atomique_remplace_le_rapport(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/test_serve_appliquer_selection_lock.py
+++ b/test_serve_appliquer_selection_lock.py
@@ -24,7 +24,7 @@ os.environ["BLINK_BOOTSTRAP"] = "none"
 _TEST_HOME = tempfile.TemporaryDirectory(prefix="blink-toggle-lock-")
 os.environ["BLINK_HOME"] = _TEST_HOME.name
 
-import runtime
+import runtime  # noqa: E402 - environnement de test posé avant import
 import serve  # noqa: E402 - bootstrap neutralisé avant import
 
 
@@ -50,7 +50,11 @@ class TestAppliquerSelectionNAttendPasLeVerrouRegistre(unittest.TestCase):
         # vrai sous-processus « merge » qui peut encore tenir un descripteur
         # sur le dossier temporaire au moment du nettoyage (PermissionError
         # Windows, tempfile._rmtree en boucle).
-        self.patch_lancer = mock.patch.object(runtime, "lancer")
+        # identite_processus() utilise aussi ce lanceur sous POSIX. Une sortie
+        # vide garde l'identité sérialisable tout en neutralisant le vrai merge.
+        self.patch_lancer = mock.patch.object(
+            runtime, "lancer", return_value=mock.Mock(stdout=""),
+        )
         self.patch_lancer.start()
 
         self.identity = "jardin/test.mp4"

--- a/test_serve_choisir_dossier.py
+++ b/test_serve_choisir_dossier.py
@@ -76,28 +76,40 @@ class TestChoisirDossier(unittest.TestCase):
     # --- Windows : PowerShell/WinForms (_choisir_dossier_windows) ---
 
     def test_windows_renvoie_le_chemin_choisi(self):
+        handler = self.construire_handler()
         with mock.patch.object(serve.os, "name", "nt"), \
+             mock.patch.object(serve.runtime, "lire_dossier_stockage",
+                               return_value="C:/depart"), \
              mock.patch.object(serve, "_choisir_dossier_windows",
                                return_value="D:/photos/blink") as appel:
-            reponses = self.appeler(self.construire_handler())
+            reponses = self.appeler(handler)
         self.assertEqual(reponses, [(200, {"path": "D:/photos/blink"})])
-        appel.assert_called_once()
+        appel.assert_called_once_with("C:/depart")
 
     def test_windows_annulation_renvoie_un_chemin_vide(self):
+        handler = self.construire_handler()
         with mock.patch.object(serve.os, "name", "nt"), \
+             mock.patch.object(serve.runtime, "lire_dossier_stockage",
+                               return_value="C:/depart"), \
              mock.patch.object(serve, "_choisir_dossier_windows", return_value=""):
-            reponses = self.appeler(self.construire_handler())
+            reponses = self.appeler(handler)
         self.assertEqual(reponses, [(200, {"path": ""})])
 
     def test_windows_echec_du_selecteur_repond_en_erreur_plutot_que_de_planter(self):
+        handler = self.construire_handler()
         with mock.patch.object(serve.os, "name", "nt"), \
-             mock.patch.object(serve, "_choisir_dossier_windows",
-                               side_effect=RuntimeError("PowerShell indisponible")):
-            reponses = self.appeler(self.construire_handler())
+             mock.patch.object(serve.runtime, "lire_dossier_stockage",
+                               return_value="C:/depart"), \
+             mock.patch.object(
+                 serve, "_choisir_dossier_windows",
+                 side_effect=RuntimeError("PowerShell indisponible"),
+             ) as appel:
+            reponses = self.appeler(handler)
         self.assertEqual(len(reponses), 1)
         code, payload = reponses[0]
         self.assertEqual(code, 500)
-        self.assertIn("error", payload)
+        self.assertEqual(payload["error"], "PowerShell indisponible")
+        appel.assert_called_once_with("C:/depart")
 
     # --- Hors Windows : repli tkinter ---
 

--- a/test_xr_local_storage.py
+++ b/test_xr_local_storage.py
@@ -117,6 +117,25 @@ class DecouverteStockageLocalTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(sync._local_storage["compatible"])
 
+    async def test_xr_actif_prime_sur_compatible_faux(self):
+        """Triplet observé sur un vrai XR : false/true/active."""
+        blink, _appareil = compte_avec_stockage_local()
+        blink.homescreen["sync_modules"][0]["local_storage_compatible"] = False
+        sync = blink_models.select_sync_modules(blink, None)[0][1]
+        poll = mock.AsyncMock(side_effect=[
+            {"id": 51},
+            {"manifest_id": 61, "clips": []},
+        ])
+
+        with mock.patch.object(sync, "poll_local_storage_manifest", new=poll):
+            clips = await blink_models.read_local_manifest(sync)
+
+        self.assertFalse(sync._local_storage["compatible"])
+        self.assertTrue(sync._local_storage["enabled"])
+        self.assertTrue(sync.local_storage)
+        self.assertEqual(clips, [])
+        self.assertEqual(poll.await_args_list, [mock.call(), mock.call(51)])
+
     async def test_manifeste_utilise_id_module_et_restitue_nom_camera(self):
         blink, _appareil = compte_avec_stockage_local()
         sync = blink_models.select_sync_modules(blink, "Jardin")[0][1]


### PR DESCRIPTION
## Summary

- let an active local-storage status take precedence over `local_storage_compatible=false`, the triplet observed on a real Sync Module XR (`compatible=false`, `enabled=true`, `status=active`)
- make Tester-XR r2 call the manifest request/read routes directly with the real homescreen Sync Module ID
- report only anonymized flags and counts, including schema and camera-mapping coverage
- build a reproducible two-file Windows test ZIP with plain-language instructions

## Why

The r1 field report was a false negative: blink2video rejected `compatible=false` before issuing any manifest API request. blinkpy 0.25.9 itself gates manifest access only on active status, and another XR-capable client follows the same behavior. The r2 tester performs the previously missing read-only API probe.

## Validation

- 386 unit tests pass
- Ruff passes on all changed Python files
- PyInstaller builds Tester-XR r2 on Windows x64
- the frozen executable starts headlessly and writes the expected anonymized v2 report
- the ZIP contains only `Tester-XR.exe` and `README-XR-test.txt`

## Hardware validation

The r1 report confirms that real XR discovery and the true storage-module ID work. A single r2 run on that XR is still needed to confirm the manifest endpoint response and clip schema.
