### PR TITLE
Corrige la régression TLS du Live View

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Instructions du dépôt
+
+## Garde-fou critique : TLS du Live View
+
+- Ne jamais modifier, remplacer ou monkey-patcher `blinkpy.livestream.BlinkLiveStream.auth` ni son contexte TLS.
+- Le relais vidéo Live View de Blink présente un certificat auto-signé. `blinkpy` lui applique volontairement un contexte `CERT_NONE` limité à cette connexion. Le remplacement par `ssl.create_default_context()` a cassé tous les directs de blink2video 0.10.6 à 0.10.10 avec `CERTIFICATE_VERIFY_FAILED`, avant le premier octet vidéo.
+- Cette exception concerne uniquement le relais vidéo Live View. Les appels ordinaires aux API Blink doivent conserver la validation TLS stricte fournie par `blink_auth.contexte_tls()`.
+- Si une évolution future semble imposer de toucher à ce comportement, arrêter le travail et demander d’abord l’autorisation explicite de l’utilisateur. Exiger ensuite le test automatisé `test_livestream_relais_auto_signe_conserve_le_contexte_amont`, la suite complète et un essai sur caméra réelle démontrant HTTP 200, codec, `moov` et `moof`.

--- a/blink_engine.py
+++ b/blink_engine.py
@@ -113,24 +113,12 @@ async def _recv_corrige(self):
 
 _blinkpy_livestream.BlinkLiveStream.recv = _recv_corrige
 
-
-async def _auth_corrige(self):
-    """Remplace BlinkLiveStream.auth (blinkpy/livestream.py) : la version
-    d'origine désactive check_hostname et utilise CERT_NONE, acceptant le
-    certificat de n'importe qui sur le chemin réseau vers le relais du
-    direct. Mêmes valeurs par défaut que blink_auth.py pour la session
-    principale (chaîne ET nom d'hôte vérifiés), rien de custom."""
-    ssl_context = _blinkpy_livestream.ssl.create_default_context()
-    self.target_reader, self.target_writer = await asyncio.open_connection(
-        self.target.hostname, self.target.port, ssl=ssl_context
-    )
-
-    auth_header = self.get_auth_header()
-    self.target_writer.write(auth_header)
-    await self.target_writer.drain()
-
-
-_blinkpy_livestream.BlinkLiveStream.auth = _auth_corrige
+# Ne pas remplacer BlinkLiveStream.auth : le relais vidéo Blink présente un
+# certificat auto-signé, et blinkpy lui applique donc un contexte TLS CERT_NONE
+# limité à cette connexion. Une validation CA classique a été tentée dans
+# v0.10.6 ; elle a cassé tous les directs avec CERTIFICATE_VERIFY_FAILED avant
+# le premier octet. Les appels API Blink ordinaires restent, eux, strictement
+# validés par blink_auth.contexte_tls().
 
 
 class CloudResult(NamedTuple):

--- a/serve.py
+++ b/serve.py
@@ -685,7 +685,9 @@ async def _stop_stream(stream, feed) -> str:
     except asyncio.TimeoutError:
         pass
     except Exception as error:
-        return f"fin de flux : {type(error).__name__}"
+        detail = str(error).strip()
+        suffixe = f" : {detail}" if detail else ""
+        return f"fin de flux : {type(error).__name__}{suffixe}"
 
     try:
         from blinkpy import api

--- a/test_blink2video_audit.py
+++ b/test_blink2video_audit.py
@@ -1760,6 +1760,36 @@ class TestsDefautsAsynchrones(unittest.IsolatedAsyncioTestCase):
 
         client.write.assert_called_once_with(charge)
 
+    async def test_livestream_relais_auto_signe_conserve_le_contexte_amont(self):
+        """Le relais vidéo Blink utilise un certificat auto-signé.
+
+        Les API ordinaires restent vérifiées par blink_auth, mais remplacer le
+        contexte spécialisé de BlinkLiveStream.auth par create_default_context
+        coupe le direct avant son premier octet (régression v0.10.6).
+        """
+        stream = blink_engine._blinkpy_livestream.BlinkLiveStream.__new__(
+            blink_engine._blinkpy_livestream.BlinkLiveStream
+        )
+        stream.target = SimpleNamespace(hostname="relay.invalid", port=443)
+        stream.get_auth_header = mock.Mock(return_value=b"AUTH\r\n")
+        reader = object()
+        writer = SimpleNamespace(write=mock.Mock(), drain=mock.AsyncMock())
+        connexion = mock.AsyncMock(return_value=(reader, writer))
+
+        with mock.patch.object(asyncio, "open_connection", new=connexion):
+            await stream.auth()
+
+        contexte = connexion.await_args.kwargs["ssl"]
+        self.assertEqual(
+            contexte.verify_mode,
+            blink_engine._blinkpy_livestream.ssl.CERT_NONE,
+        )
+        self.assertFalse(contexte.check_hostname)
+        self.assertIs(stream.target_reader, reader)
+        self.assertIs(stream.target_writer, writer)
+        writer.write.assert_called_once_with(b"AUTH\r\n")
+        writer.drain.assert_awaited_once_with()
+
 
 class FauxProcessusServe:
     """Simule le subprocess.Popen de « serve » lancé par accueillir()."""


### PR DESCRIPTION
## Correctif\n- restaure le contexte TLS spécialisé de blinkpy pour le relais Live View auto-signé\n- conserve la validation TLS stricte des API Blink ordinaires\n- ajoute un test de non-régression ciblé et un garde-fou durable dans AGENTS.md\n- enrichit le diagnostic d'arrêt du flux avec le détail de l'exception\n\n## Validation\n- 407 tests passent\n- Ruff ciblé propre\n- essai sur caméra réelle : HTTP 200, codec détecté, fragments moov et moof reçus